### PR TITLE
[config] Remove token from configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ out/
 .bloop/
 .vscode/
 .metals/
-
+token.conf

--- a/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
+++ b/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
@@ -1,11 +1,9 @@
 package com.bot4s.zmatrix
 
-import zio.{ Has, IO, Layer, Managed, Ref, UIO, URIO, ZIO }
-import pureconfig.{ ConfigSource, ConfigWriter }
+import zio.{ Has, IO, Layer, Ref, UIO, URIO, ZIO }
+import pureconfig.ConfigSource
 import pureconfig.generic.auto._
 import pureconfig.error.ConfigReaderFailures
-import java.io.{ BufferedWriter, File, FileWriter }
-import com.typesafe.config.ConfigRenderOptions
 
 final case class Config(
   matrix: MatrixConfigurationContent
@@ -15,8 +13,7 @@ final case class MatrixConfigurationContent(
   apiPrefix: String = MatrixConfiguration.DEFAULT_API_PREFIX,
   userId: Option[String] = None,
   deviceName: Option[String] = None,
-  deviceId: Option[String] = None,
-  since: Option[String] = None
+  deviceId: Option[String] = None
 ) {
   val apiPath = f"${homeServer}${apiPrefix}"
 }
@@ -25,7 +22,6 @@ final case class MatrixConfigurationContent(
  */
 trait MatrixConfiguration {
   def get: UIO[Config]
-  def set(config: Config): UIO[Unit]
 }
 
 object MatrixConfiguration {
@@ -33,46 +29,18 @@ object MatrixConfiguration {
   val DEFAULT_API_PREFIX  = "/_matrix/client/r0"
   val DEFAULT_CONFIG_FILE = "bot.conf"
 
-  def get: URIO[Has[MatrixConfiguration], Config]               = ZIO.accessM(_.get.get)
-  def set(config: Config): URIO[Has[MatrixConfiguration], Unit] = ZIO.accessM(_.get.set(config))
+  def get: URIO[Has[MatrixConfiguration], Config] = ZIO.accessM(_.get.get)
 
   private def refFromFile(filename: String): IO[ConfigReaderFailures, Ref[Config]] =
     ZIO.fromEither(ConfigSource.resources(filename).load[Config]) >>= Ref.make
 
   /**
    * Create an in-memory configuration that is not persistent.
-   * This is not recommended as the pagination `since` token will not be kept between two runs.
    */
   def live(filename: String = DEFAULT_CONFIG_FILE): Layer[ConfigReaderFailures, Has[MatrixConfiguration]] =
     refFromFile(filename).map { configRef =>
       new MatrixConfiguration {
-        override def get: UIO[Config]               = configRef.get
-        override def set(config: Config): UIO[Unit] = configRef.set(config)
-      }
-    }.toLayer
-
-  /**
-   * Create a persistent (on disk storage) configuration from the given file.
-   * This layer, when updated, will write back its changes in the given configuration file
-   */
-  def persistent(filename: String = DEFAULT_CONFIG_FILE): Layer[ConfigReaderFailures, Has[MatrixConfiguration]] =
-    refFromFile(filename).map { configRef =>
-      new MatrixConfiguration {
         override def get: UIO[Config] = configRef.get
-        override def set(config: Config): UIO[Unit] = {
-          val renderOptions = ConfigRenderOptions.concise().setFormatted(true).setJson(false)
-          val toWrite       = ConfigWriter[Config].to(config).render(renderOptions)
-
-          val updateConf = for {
-            uri    <- ZIO.fromOption(Option(getClass().getClassLoader().getResource(filename)))
-            file    = new File(uri.toURI())
-            managed = Managed.make(ZIO.effect(new BufferedWriter(new FileWriter(file))))(bw => IO.succeed(bw.close))
-            _      <- configRef.set(config)
-            _      <- managed.use(c => IO.effect(c.write(toWrite)))
-          } yield ()
-
-          updateConf.catchAll(_ => IO.succeed(()))
-        }
       }
     }.toLayer
 

--- a/core/src/com/bot4s/zmatrix/MatrixTokenConfiguration.scala
+++ b/core/src/com/bot4s/zmatrix/MatrixTokenConfiguration.scala
@@ -1,0 +1,67 @@
+package com.bot4s.zmatrix
+
+import zio.{ Has, IO, Layer, Managed, Ref, UIO, URIO, ZIO }
+import pureconfig.{ ConfigSource, ConfigWriter }
+import pureconfig.generic.auto._
+import pureconfig.error.ConfigReaderFailures
+import java.io.{ BufferedWriter, File, FileWriter }
+import com.typesafe.config.ConfigRenderOptions
+
+final case class MatrixToken(
+  since: Option[String] = None
+)
+
+trait MatrixTokenConfiguration {
+  def get: UIO[MatrixToken]
+  def set(config: MatrixToken): UIO[Unit]
+}
+
+object MatrixTokenConfiguration {
+  val DEFAULT_TOKEN_FILE = "token.conf"
+
+  def get: URIO[Has[MatrixTokenConfiguration], MatrixToken]               = ZIO.accessM(_.get.get)
+  def set(config: MatrixToken): URIO[Has[MatrixTokenConfiguration], Unit] = ZIO.accessM(_.get.set(config))
+
+  private def refFromFile(filename: String): IO[ConfigReaderFailures, Ref[MatrixToken]] =
+    ZIO
+      .fromEither(ConfigSource.file(filename).load[MatrixToken])
+      .orElse(ZIO.succeed(MatrixToken(None))) >>= Ref.make
+
+  /**
+   * Create an in-memory configuration that is not persistent.
+   * It's not recommended to use this layer as the token will not be persisted
+   * between runs
+   */
+  def live(filename: String = DEFAULT_TOKEN_FILE): Layer[ConfigReaderFailures, Has[MatrixTokenConfiguration]] =
+    refFromFile(filename).map { tokenRef =>
+      new MatrixTokenConfiguration {
+        def get: UIO[MatrixToken]               = tokenRef.get
+        def set(config: MatrixToken): UIO[Unit] = tokenRef.set(config)
+      }
+    }.toLayer
+
+  /**
+   * Create a persistent (on disk storage) configuration from the given file.
+   * This layer, when updated, will write back its changes in the given configuration file
+   */
+  def persistent(filename: String = DEFAULT_TOKEN_FILE): Layer[ConfigReaderFailures, Has[MatrixTokenConfiguration]] =
+    refFromFile(filename).map { configRef =>
+      new MatrixTokenConfiguration {
+        override def get: UIO[MatrixToken] = configRef.get
+        override def set(config: MatrixToken): UIO[Unit] = {
+          val renderOptions = ConfigRenderOptions.concise().setFormatted(true).setJson(false)
+          val toWrite       = ConfigWriter[MatrixToken].to(config).render(renderOptions)
+
+          val updateConf = for {
+            file   <- ZIO.effect(new File(filename))
+            managed = Managed.make(ZIO.effect(new BufferedWriter(new FileWriter(file))))(bw => IO.succeed(bw.close))
+            _      <- configRef.set(config)
+            _      <- managed.use(c => IO.effect(c.write(toWrite)))
+          } yield ()
+
+          updateConf.catchAll(_ => IO.succeed(()))
+        }
+      }
+    }.toLayer
+
+}

--- a/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
@@ -36,7 +36,7 @@ trait MatrixRequests {
   def withSince(
     request: Request[MatrixResponse[Json], Any]
   ) = ZIO.accessM[AuthMatrixEnv] { env =>
-    val config = env.get[MatrixTokenConfiguration]
+    val config = env.get[SyncTokenConfiguration]
     config.get.map { config =>
       val uriWithParam = request.uri.addParam("since", config.since)
       request.copy[Identity, MatrixResponse[Json], Any](uri = uriWithParam)

--- a/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
@@ -36,9 +36,9 @@ trait MatrixRequests {
   def withSince(
     request: Request[MatrixResponse[Json], Any]
   ) = ZIO.accessM[AuthMatrixEnv] { env =>
-    val config = env.get[MatrixConfiguration]
+    val config = env.get[MatrixTokenConfiguration]
     config.get.map { config =>
-      val uriWithParam = request.uri.addParam("since", config.matrix.since)
+      val uriWithParam = request.uri.addParam("since", config.since)
       request.copy[Identity, MatrixResponse[Json], Any](uri = uriWithParam)
     }
   }

--- a/core/src/com/bot4s/zmatrix/package.scala
+++ b/core/src/com/bot4s/zmatrix/package.scala
@@ -10,16 +10,16 @@ package object zmatrix extends MatrixRequests {
   type MatrixEnv = ZEnv
     with Has[MatrixClient]
     with Has[MatrixConfiguration]
-    with Has[MatrixTokenConfiguration]
+    with Has[SyncTokenConfiguration]
     with Logging
   type AuthMatrixEnv = MatrixEnv with Has[Authentication]
 
   implicit class ExtendedZIOState[R, E](x: ZIO[R, E, SyncState]) {
 
-    def updateState[R1 <: R with Has[MatrixTokenConfiguration], E1 >: E]()
-      : ZIO[R1 with Has[MatrixTokenConfiguration], E1, SyncState] = x.tap[R1, E1] { syncState =>
-      MatrixTokenConfiguration.get.flatMap { config =>
-        MatrixTokenConfiguration.set(config.copy(since = Some(syncState.nextBatch)))
+    def updateState[R1 <: R with Has[SyncTokenConfiguration], E1 >: E]()
+      : ZIO[R1 with Has[SyncTokenConfiguration], E1, SyncState] = x.tap[R1, E1] { syncState =>
+      SyncTokenConfiguration.get.flatMap { config =>
+        SyncTokenConfiguration.set(config.copy(since = Some(syncState.nextBatch)))
       }
     }
 

--- a/core/src/com/bot4s/zmatrix/package.scala
+++ b/core/src/com/bot4s/zmatrix/package.scala
@@ -7,15 +7,19 @@ import zio.logging._
 import com.bot4s.zmatrix.services.Authentication
 
 package object zmatrix extends MatrixRequests {
-  type MatrixEnv     = ZEnv with Has[MatrixClient] with Has[MatrixConfiguration] with Logging
+  type MatrixEnv = ZEnv
+    with Has[MatrixClient]
+    with Has[MatrixConfiguration]
+    with Has[MatrixTokenConfiguration]
+    with Logging
   type AuthMatrixEnv = MatrixEnv with Has[Authentication]
 
   implicit class ExtendedZIOState[R, E](x: ZIO[R, E, SyncState]) {
 
-    def updateState[R1 <: R with Has[MatrixConfiguration], E1 >: E]()
-      : ZIO[R1 with Has[MatrixConfiguration], E1, SyncState] = x.tap[R1, E1] { syncState =>
-      MatrixConfiguration.get.flatMap { config =>
-        MatrixConfiguration.set(config.copy(matrix = config.matrix.copy(since = Some(syncState.nextBatch))))
+    def updateState[R1 <: R with Has[MatrixTokenConfiguration], E1 >: E]()
+      : ZIO[R1 with Has[MatrixTokenConfiguration], E1, SyncState] = x.tap[R1, E1] { syncState =>
+      MatrixTokenConfiguration.get.flatMap { config =>
+        MatrixTokenConfiguration.set(config.copy(since = Some(syncState.nextBatch)))
       }
     }
 

--- a/examples/src/com/bot4s/zmatrix/ExampleApp.scala
+++ b/examples/src/com/bot4s/zmatrix/ExampleApp.scala
@@ -19,7 +19,7 @@ trait ExampleApp extends zio.App {
     .inject(
       ZEnv.live,
       Logger.live("matrix-zio-main"),
-      MatrixTokenConfiguration
+      SyncTokenConfiguration
         .persistent()
         .mapError(x => new Exception(s"Unable to read token configuration $x"))
         .orDie,

--- a/examples/src/com/bot4s/zmatrix/ExampleApp.scala
+++ b/examples/src/com/bot4s/zmatrix/ExampleApp.scala
@@ -19,6 +19,10 @@ trait ExampleApp extends zio.App {
     .inject(
       ZEnv.live,
       Logger.live("matrix-zio-main"),
+      MatrixTokenConfiguration
+        .persistent()
+        .mapError(x => new Exception(s"Unable to read token configuration $x"))
+        .orDie,
       MatrixConfiguration.live().mapError(x => new Exception(s"Unable to read configuration $x")).orDie,
       Authentication.live,
       AsyncHttpClientZioBackend.layer().orDie,


### PR DESCRIPTION
The usage of the resource file to store the `since` token is not correct.
This token should be placed into its own file to avoid erasing the content of bot.conf