### PR TITLE
feat(api): logout api and token extension methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out/
 .bloop/
+.bsp/
 .vscode/
 .metals/
 token.conf

--- a/build.sc
+++ b/build.sc
@@ -48,7 +48,7 @@ class CoreModule(val crossScalaVersion: String) extends ExtendedCrossScalaModule
     ivy"dev.zio::zio-logging:${zioLoggingVersion}",
     ivy"com.softwaremill.sttp.client3::core:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::circe:${sttpVersion}",
-    ivy"com.softwaremill.sttp.client3::async-http-client-backend-zio:${sttpVersion}",
+    ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}",
     ivy"com.github.pureconfig::pureconfig:${pureConfigVersion}",
     ivy"io.circe::circe-generic:${circeVersion}",
     ivy"io.circe::circe-generic-extras:${circeVersion}",

--- a/core/src/com/bot4s/zmatrix/api/Logout.scala
+++ b/core/src/com/bot4s/zmatrix/api/Logout.scala
@@ -1,0 +1,12 @@
+package com.bot4s.zmatrix.api
+
+trait Logout {
+
+  def logout =
+    sendWithAuth[Unit](post(Seq("logout")))
+
+  def logoutAll =
+    sendWithAuth[Unit](post(Seq("logout", "all")))
+}
+
+object logout extends Logout

--- a/examples/src/com/bot4s/zmatrix/ExampleApp.scala
+++ b/examples/src/com/bot4s/zmatrix/ExampleApp.scala
@@ -2,28 +2,16 @@ package com.bot4s.zmatrix
 
 import zio.{ Schedule, _ }
 
-import com.bot4s.zmatrix.MatrixError.{ NetworkError, ResponseError }
 import com.bot4s.zmatrix.client.MatrixClient
 import com.bot4s.zmatrix.services.Authentication
-import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
+import sttp.client3.httpclient.zio.HttpClientZioBackend
 
 trait ExampleApp[T] extends zio.ZIOAppDefault {
 
   def runExample: ZIO[AuthMatrixEnv, MatrixError, T]
 
   override def run: ZIO[Environment, Any, ExitCode] =
-    runExample.catchSome { case ResponseError("M_MISSING_TOKEN", _, _) | ResponseError("M_UNKNOWN_TOKEN", _, _) =>
-      for {
-        _ <- ZIO.logError("Invalid or empty token provided, trying password authentication")
-        // We want to retry authentication only in case of network error, any other error should terminate the fiber instead
-        _ <- Authentication.refresh
-               .tapError(x => ZIO.logError(x.toString()))
-               .refineOrDie { case x: NetworkError => x }
-               .retry(Schedule.exponential(1.seconds))
-               .tap(token => ZIO.logInfo(token.token))
-        program <- runExample
-      } yield program
-    }
+    runExample.withAutoRefresh
       .tapError(error => ZIO.logError(error.toString()))
       .retry(Schedule.forever)
       .exitCode
@@ -34,7 +22,7 @@ trait ExampleApp[T] extends zio.ZIOAppDefault {
           .orDie,
         MatrixConfiguration.live().mapError(x => new Exception(s"Unable to read configuration $x")).orDie,
         Authentication.live,
-        AsyncHttpClientZioBackend.layer().orDie,
+        HttpClientZioBackend.layer().orDie,
         MatrixClient.live
       )
 

--- a/examples/src/com/bot4s/zmatrix/Upload.scala
+++ b/examples/src/com/bot4s/zmatrix/Upload.scala
@@ -3,10 +3,11 @@ package com.bot4s.zmatrix
 import zio.Console.printLine
 import zio.ZIO
 
+import java.io.File
+
 import com.bot4s.zmatrix.api.media
 import sttp.client3._
 import sttp.model.MediaType
-import java.io.File
 
 object Upload extends ExampleApp[Unit] {
 


### PR DESCRIPTION
- Remove deprecated AsyncHttp client for sttp
- Add Logout endpoints
- Introduce `withAutoRefresh` extension method to deal with token errors and refresh and any API call