### PR TITLE
chore(deps): migrate to zio-json

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -10,7 +10,6 @@ object Versions {
   val zioLoggingVersion     = "2.1.3"
   val zioVersion            = "2.0.2"
   val sttpVersion           = "3.8.3"
-  val circeVersion          = "0.14.3"
   val pureConfigVersion     = "0.17.1"
   val scalafixModuleVersion = "0.6.0"
 }
@@ -45,13 +44,12 @@ class CoreModule(val crossScalaVersion: String) extends ExtendedCrossScalaModule
 
   override def ivyDeps = Agg(
     ivy"dev.zio::zio:${zioVersion}",
+    ivy"dev.zio::zio-json:0.3.0",
     ivy"dev.zio::zio-logging:${zioLoggingVersion}",
     ivy"com.softwaremill.sttp.client3::core:${sttpVersion}",
-    ivy"com.softwaremill.sttp.client3::circe:${sttpVersion}",
+    ivy"com.softwaremill.sttp.client3::zio-json:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}",
     ivy"com.github.pureconfig::pureconfig:${pureConfigVersion}",
-    ivy"io.circe::circe-generic:${circeVersion}",
-    ivy"io.circe::circe-generic-extras:${circeVersion}",
     // https://github.com/com-lihaoyi/mill/issues/1797
     ivy"org.scala-lang:scala-reflect:${crossScalaVersion}"
   )

--- a/core/src/com/bot4s/zmatrix/Matrix.scala
+++ b/core/src/com/bot4s/zmatrix/Matrix.scala
@@ -1,24 +1,24 @@
 package com.bot4s.zmatrix
 
 import zio._
+import zio.json.JsonDecoder
 
 import com.bot4s.zmatrix.api._
 import com.bot4s.zmatrix.client._
 import com.bot4s.zmatrix.core.JsonRequest
 import com.bot4s.zmatrix.core.RequestAuth._
 import com.bot4s.zmatrix.services.Authentication
-import io.circe._
 
 trait MatrixApiBase extends MatrixRequests with MatrixParser {
   def client: MatrixClient
 
-  def send[T](request: JsonRequest)(implicit decoder: Decoder[T]): IO[MatrixError, T] =
+  def send[T](request: JsonRequest)(implicit decoder: JsonDecoder[T]): IO[MatrixError, T] =
     for {
       response <- client.send(request)
       decoded  <- as(response)(decoder)
     } yield decoded
 
-  def sendWithAuth[T](request: JsonRequest)(implicit decoder: Decoder[T]): ZIO[AuthMatrixEnv, MatrixError, T] =
+  def sendWithAuth[T](request: JsonRequest)(implicit decoder: JsonDecoder[T]): ZIO[AuthMatrixEnv, MatrixError, T] =
     for {
       token    <- Authentication.accessToken
       withAuth  = request.withAuth(TokenAuth(token.token))

--- a/core/src/com/bot4s/zmatrix/MatrixError.scala
+++ b/core/src/com/bot4s/zmatrix/MatrixError.scala
@@ -1,7 +1,6 @@
 package com.bot4s.zmatrix
 
-import io.circe.generic.semiauto.deriveDecoder
-import io.circe.{ Decoder, Error }
+import zio.json._
 
 sealed trait MatrixError extends Exception
 
@@ -10,8 +9,8 @@ object MatrixError {
       extends Exception(s"Network Error $error")
       with MatrixError
 
-  final case class SerializationError(body: String, error: Error)
-      extends Exception(s"Serialization error $body ${error.getMessage}")
+  final case class SerializationError(body: String, error: String)
+      extends Exception(s"Serialization error $body $error")
       with MatrixError
 
   final case class InvalidParameterError(name: String, msg: String)
@@ -26,7 +25,7 @@ object MatrixError {
       extends Exception(s"Client Error $error")
       with MatrixError
 
-  implicit val responseErrorDecoder: Decoder[ResponseError] =
-    deriveDecoder[ResponseError]
+  implicit val responseErrorDecoder: JsonDecoder[ResponseError] =
+    DeriveJsonDecoder.gen[ResponseError]
 
 }

--- a/core/src/com/bot4s/zmatrix/api/DeviceManagement.scala
+++ b/core/src/com/bot4s/zmatrix/api/DeviceManagement.scala
@@ -1,6 +1,7 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json.ast._
 
 import com.bot4s.zmatrix.models.Device
 import com.bot4s.zmatrix.{ MatrixError, _ }
@@ -11,7 +12,9 @@ trait DeviceManagement { self: MatrixApiBase =>
    * Documentation: https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-devices
    */
   def getDevices: ZIO[AuthMatrixEnv, MatrixError, List[Device]] =
-    sendWithAuth(get(Seq("devices")))(_.downField("devices").as[List[Device]])
+    sendWithAuth[List[Device]](get(Seq("devices")))(
+      Json.decoder.mapOrFail(_.get(JsonCursor.field("devices")).flatMap(_.as[List[Device]]))
+    )
 }
 
 private[zmatrix] trait DeviceManagementAccessors {

--- a/core/src/com/bot4s/zmatrix/api/Login.scala
+++ b/core/src/com/bot4s/zmatrix/api/Login.scala
@@ -1,11 +1,11 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json.ast.Json
 
 import com.bot4s.zmatrix.models.EventType
 import com.bot4s.zmatrix.models.responses._
 import com.bot4s.zmatrix.{ Matrix, MatrixApiBase, MatrixEnv, MatrixError }
-import io.circe.Json
 
 trait Login { self: MatrixApiBase =>
   def passwordLogin(
@@ -14,13 +14,12 @@ trait Login { self: MatrixApiBase =>
     deviceId: Option[String]
   ) = {
     val json = Json
-      .obj(
-        "type"      -> Json.fromString(EventType.passwordLogin.toString()),
-        "user"      -> Json.fromString(user),
-        "password"  -> Json.fromString(password),
-        "device_id" -> deviceId.map(Json.fromString(_)).getOrElse(Json.Null)
+      .Obj(
+        "type"      -> Json.Str(EventType.passwordLogin.toString()),
+        "user"      -> Json.Str(user),
+        "password"  -> Json.Str(password),
+        "device_id" -> deviceId.map(Json.Str(_)).getOrElse(Json.Null)
       )
-      .deepDropNullValues
 
     send[LoginResponse](postJson(Seq("login"), json))
   }
@@ -29,10 +28,10 @@ trait Login { self: MatrixApiBase =>
     token: String,
     deviceId: Option[String] = None
   ): ZIO[MatrixEnv, MatrixError, LoginResponse] = {
-    val json = Json.obj(
-      "type"      -> Json.fromString(EventType.tokenLogin.toString()),
-      "token"     -> Json.fromString(token),
-      "device_id" -> deviceId.map(Json.fromString(_)).getOrElse(Json.Null)
+    val json = Json.Obj(
+      "type"      -> Json.Str(EventType.tokenLogin.toString()),
+      "token"     -> Json.Str(token),
+      "device_id" -> deviceId.map(Json.Str(_)).getOrElse(Json.Null)
     )
 
     send[LoginResponse](postJson(Seq("login"), json))

--- a/core/src/com/bot4s/zmatrix/api/Logout.scala
+++ b/core/src/com/bot4s/zmatrix/api/Logout.scala
@@ -1,6 +1,7 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json.ast.Json
 
 import com.bot4s.zmatrix.{ Matrix, MatrixApiBase }
 
@@ -11,14 +12,14 @@ trait Logout { self: MatrixApiBase =>
    * Documentation: https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-logout
    */
   def logout =
-    sendWithAuth[Unit](post(Seq("logout")))
+    sendWithAuth[Json](post(Seq("logout"))).as(())
 
   /*
    * Delete all existing tokens for the user. The current token will be invalidated
    * Documentation: https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-logout-all
    */
   def logoutAll =
-    sendWithAuth[Unit](post(Seq("logout", "all")))
+    sendWithAuth[Json](post(Seq("logout", "all"))).as(())
 }
 
 private[zmatrix] trait LogoutAccessors {

--- a/core/src/com/bot4s/zmatrix/api/RoomCreation.scala
+++ b/core/src/com/bot4s/zmatrix/api/RoomCreation.scala
@@ -1,10 +1,10 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json.ast._
 
 import com.bot4s.zmatrix.models.{ RoomCreationData, RoomId }
 import com.bot4s.zmatrix.{ AuthMatrixEnv, Matrix, MatrixApiBase, MatrixError }
-import io.circe.syntax._
 
 trait RoomCreation { self: MatrixApiBase =>
 
@@ -13,7 +13,9 @@ trait RoomCreation { self: MatrixApiBase =>
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-createroom
    */
   def createRoom(roomCreation: RoomCreationData): ZIO[AuthMatrixEnv, MatrixError, RoomId] =
-    sendWithAuth(postJson(Seq("createRoom"), roomCreation.asJson.dropNullValues))(_.downField("room_id").as[RoomId])
+    sendWithAuth[RoomId](postJson(Seq("createRoom"), roomCreation))(
+      Json.decoder.mapOrFail(_.get(JsonCursor.field("room_id")).flatMap(_.as[RoomId]))
+    )
 
 }
 

--- a/core/src/com/bot4s/zmatrix/api/RoomMembership.scala
+++ b/core/src/com/bot4s/zmatrix/api/RoomMembership.scala
@@ -1,11 +1,11 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json.ast._
 
 import com.bot4s.zmatrix.models.RoomId
 import com.bot4s.zmatrix.models.responses._
 import com.bot4s.zmatrix.{ AuthMatrixEnv, Matrix, MatrixApiBase, MatrixError }
-import io.circe.Json
 
 trait RoomMembership { self: MatrixApiBase =>
 
@@ -21,80 +21,82 @@ trait RoomMembership { self: MatrixApiBase =>
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-joined-rooms
    */
   def joinedRooms: ZIO[AuthMatrixEnv, MatrixError, List[RoomId]] =
-    sendWithAuth[List[RoomId]](get(Seq("joined_rooms")))(_.downField("joined_rooms").as[List[RoomId]])
+    sendWithAuth[List[RoomId]](get(Seq("joined_rooms")))(
+      Json.decoder.mapOrFail(_.get(JsonCursor.field("joined_rooms")).flatMap(_.as[List[RoomId]]))
+    )
 
   /**
    * Invite a user in the given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-invite
    */
   def invite(roomId: RoomId, user: String): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](postJson(Seq("rooms", roomId.id, "invite"), Json.obj("user_id" -> Json.fromString(user))))
+    sendWithAuth[Json](postJson(Seq("rooms", roomId.id, "invite"), Json.Obj("user_id" -> Json.Str(user)))).as(())
 
   /**
    * Forget the given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-forget
    */
   def forget(roomId: RoomId): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](
+    sendWithAuth[Json](
       post(
         Seq("rooms", roomId.id, "forget")
       )
-    )
+    ).as(())
 
   /**
    * Leave the given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-leave
    */
   def leave(roomId: RoomId): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](
+    sendWithAuth[Json](
       post(
         Seq("rooms", roomId.id, "leave")
       )
-    )
+    ).as(())
 
   /**
    * Ban the user from a  given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-ban
    */
   def ban(roomId: RoomId, user: String, reason: Option[String] = None): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](
+    sendWithAuth[Json](
       postJson(
         Seq("rooms", roomId.id, "ban"),
-        Json.obj(
-          "user_id" -> Json.fromString(user),
-          "reason"  -> Json.fromString(reason.getOrElse(""))
+        Json.Obj(
+          "user_id" -> Json.Str(user),
+          "reason"  -> Json.Str(reason.getOrElse(""))
         )
       )
-    )
+    ).as(())
 
   /**
    * Uban the user from a given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-unban
    */
   def unban(roomId: RoomId, user: String): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](
+    sendWithAuth[Json](
       postJson(
         Seq("rooms", roomId.id, "unban"),
-        Json.obj(
-          "user_id" -> Json.fromString(user)
+        Json.Obj(
+          "user_id" -> Json.Str(user)
         )
       )
-    )
+    ).as(())
 
   /**
    * Kick the user from a  given room
    * Documentation: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-rooms-roomid-kick
    */
   def kick(roomId: RoomId, user: String, reason: Option[String] = None): ZIO[AuthMatrixEnv, MatrixError, Unit] =
-    sendWithAuth[Unit](
+    sendWithAuth[Json](
       postJson(
         Seq("rooms", roomId.id, "kick"),
-        Json.obj(
-          "user_id" -> Json.fromString(user),
-          "reason"  -> Json.fromString(reason.getOrElse(""))
+        Json.Obj(
+          "user_id" -> Json.Str(user),
+          "reason"  -> Json.Str(reason.getOrElse(""))
         )
       )
-    )
+    ).as(())
 
 }
 

--- a/core/src/com/bot4s/zmatrix/api/Rooms.scala
+++ b/core/src/com/bot4s/zmatrix/api/Rooms.scala
@@ -1,6 +1,7 @@
 package com.bot4s.zmatrix.api
 
 import zio.ZIO
+import zio.json._
 
 import java.util.UUID
 
@@ -8,7 +9,6 @@ import com.bot4s.zmatrix.models.RoomMessageType._
 import com.bot4s.zmatrix.models.responses.EventResponse
 import com.bot4s.zmatrix.models.{ EventType, RoomId, RoomMessageType }
 import com.bot4s.zmatrix.{ Matrix, MatrixApiBase }
-import io.circe.syntax._
 
 trait Rooms { self: MatrixApiBase =>
 
@@ -18,11 +18,11 @@ trait Rooms { self: MatrixApiBase =>
    * https://spec.matrix.org/latest/client-server-api/#mtext
    */
   def sendEvent(roomId: RoomId, messageEvent: RoomMessageType) =
-    ZIO.logDebug(messageEvent.asJson.toString()) *>
+    ZIO.logDebug(messageEvent.toJson) *>
       sendWithAuth[EventResponse](
         putJson(
           Seq("rooms", roomId.id, "send", EventType.roomMessages.toString(), UUID.randomUUID().toString()),
-          messageEvent.asJson
+          messageEvent
         )
       )
 
@@ -30,7 +30,7 @@ trait Rooms { self: MatrixApiBase =>
     sendWithAuth[EventResponse](
       putJson(
         Seq("rooms", roomId.id, "send", EventType.roomMessages.toString(), UUID.randomUUID().toString()),
-        RoomMessageTextContent(message).asJson
+        RoomMessageTextContent(message)
       )
     )
 

--- a/core/src/com/bot4s/zmatrix/client/MatrixClient.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixClient.scala
@@ -1,11 +1,11 @@
 package com.bot4s.zmatrix.client
 
+import zio.json.ast.Json
 import zio.{ IO, Task, URLayer, ZIO, ZLayer }
 
 import com.bot4s.zmatrix.MatrixError.NetworkError
 import com.bot4s.zmatrix._
 import com.bot4s.zmatrix.core.{ ApiScope, JsonRequest }
-import io.circe.Json
 import sttp.client3._
 
 /**

--- a/core/src/com/bot4s/zmatrix/client/MatrixParser.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixParser.scala
@@ -1,12 +1,13 @@
 package com.bot4s.zmatrix.client
 
+import zio.json.JsonDecoder
+import zio.json.ast.Json
 import zio.{ IO, ZIO }
 
 import com.bot4s.zmatrix.MatrixError._
-import io.circe.{ Decoder, Json }
 
 trait MatrixParser {
-  def as[T](json: Json)(implicit decoder: Decoder[T]): IO[SerializationError, T] =
+  def as[T](json: Json)(implicit decoder: JsonDecoder[T]): IO[SerializationError, T] =
     ZIO.fromEither(json.as[T]).mapError { decoding =>
       SerializationError(json.toString, decoding)
     }

--- a/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixRequests.scala
@@ -1,10 +1,10 @@
 package com.bot4s.zmatrix.client
 
+import zio.json.JsonEncoder
 import zio.{ URIO, ZIO }
 
 import com.bot4s.zmatrix._
 import com.bot4s.zmatrix.core.{ ApiScope, JsonRequest, MatrixBody }
-import io.circe.Json
 import sttp.model.{ MediaType, Method }
 
 /**
@@ -17,14 +17,14 @@ trait MatrixRequests {
   def get(path: Seq[String]) =
     JsonRequest(Method.GET, path)
 
-  def postJson(path: Seq[String], body: Json) =
+  def postJson[T: JsonEncoder](path: Seq[String], body: T) =
     sendJson(Method.POST, path, body)
 
-  def putJson(path: Seq[String], body: Json) =
+  def putJson[T: JsonEncoder](path: Seq[String], body: T) =
     sendJson(Method.PUT, path, body)
 
   def post(path: Seq[String]) =
-    postJson(path, Json.obj())
+    JsonRequest(Method.POST, path, MatrixBody.EmptyBody)
 
   /*
     This method is a bit specific as it is only for `media` file
@@ -41,6 +41,6 @@ trait MatrixRequests {
       }
     }
 
-  private def sendJson(method: Method, path: Seq[String], body: Json) =
-    JsonRequest(method, path, MatrixBody.JsonBody(body.deepDropNullValues))
+  private def sendJson[T: JsonEncoder](method: Method, path: Seq[String], body: T) =
+    JsonRequest(method, path, MatrixBody.JsonBody(body))
 }

--- a/core/src/com/bot4s/zmatrix/core/JsonRequest.scala
+++ b/core/src/com/bot4s/zmatrix/core/JsonRequest.scala
@@ -1,11 +1,12 @@
 package com.bot4s.zmatrix.core
 
+import zio.json.ast.Json
+
 import com.bot4s.zmatrix.MatrixError
 import com.bot4s.zmatrix.core.MatrixBody.EmptyBody
 import com.bot4s.zmatrix.core.RequestAuth._
-import io.circe.Json
 import sttp.client3._
-import sttp.client3.circe._
+import sttp.client3.ziojson._
 import sttp.client3.{ Request => HttpRequest }
 import sttp.model.Method
 
@@ -41,10 +42,11 @@ final case class JsonRequest(
       case EmptyBody =>
         basicRequest
           .method(method, uri"$baseUri/$path")
-      case MatrixBody.JsonBody(json) =>
+      case body @ MatrixBody.JsonBody(json) =>
+        implicit val encoder = body.encoder
         basicRequest
           .method(method, uri"$baseUri/$path")
-          .body(json.deepDropNullValues)
+          .body(json)
       case MatrixBody.ByteBody(body, contentType) =>
         basicRequest
           .method(method, uri"$baseUri/$path")

--- a/core/src/com/bot4s/zmatrix/core/MatrixBody.scala
+++ b/core/src/com/bot4s/zmatrix/core/MatrixBody.scala
@@ -1,12 +1,17 @@
 package com.bot4s.zmatrix.core
 
-import io.circe.Json
+import zio.json._
+
 import sttp.model.MediaType
 
 sealed trait MatrixBody
+
 object MatrixBody {
-  case object EmptyBody                                          extends MatrixBody
-  case class JsonBody(json: Json)                                extends MatrixBody
+  case object EmptyBody extends MatrixBody
+  case class JsonBody[T: JsonEncoder](json: T) extends MatrixBody {
+    val encoder = implicitly[JsonEncoder[T]]
+    def encode  = json.toJson
+  }
   case class ByteBody(body: Array[Byte], contentType: MediaType) extends MatrixBody
 
   val empty = EmptyBody

--- a/core/src/com/bot4s/zmatrix/models/AccessToken.scala
+++ b/core/src/com/bot4s/zmatrix/models/AccessToken.scala
@@ -1,12 +1,11 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import zio.json._
 
 final case class AccessToken(token: String) extends AnyVal
 
 object AccessToken {
   // We want to support both the derivation with the token field and also a flattened "anyval" decoding
-  implicit val decoder: Decoder[AccessToken] =
-    deriveConfiguredDecoder[AccessToken] or Decoder[String].map(x => AccessToken(x))
+  implicit val roomIdDecoder: JsonDecoder[AccessToken] =
+    DeriveJsonDecoder.gen[AccessToken] orElse JsonDecoder[String].map(AccessToken.apply)
 }

--- a/core/src/com/bot4s/zmatrix/models/Device.scala
+++ b/core/src/com/bot4s/zmatrix/models/Device.scala
@@ -1,15 +1,14 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import zio.json._
 
 final case class Device(
-  deviceId: String,
-  displayName: Option[String],
-  lastSeenIp: Option[String],
-  lastSeenTs: Option[Long]
+  @jsonField("device_id") deviceId: String,
+  @jsonField("display_name") displayName: Option[String],
+  @jsonField("last_seen_ip") lastSeenIp: Option[String],
+  @jsonField("last_seen_ts") lastSeenTs: Option[Long]
 )
 
 object Device {
-  implicit val decoder: Decoder[Device] = deriveConfiguredDecoder
+  implicit val decoder: JsonDecoder[Device] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/ImageInfo.scala
+++ b/core/src/com/bot4s/zmatrix/models/ImageInfo.scala
@@ -1,17 +1,16 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.generic.extras.semiauto.{ deriveConfiguredDecoder, deriveConfiguredEncoder }
-import io.circe.{ Decoder, Encoder }
+import zio.json._
 
 case class ImageInfo(
   h: Option[Int] = None,
   w: Option[Int] = None,
   mimetype: Option[String] = None,
   size: Option[Int] = None,
-  thumbnailUrl: Option[String] = None
+  @jsonField("thumbnail_url") thumbnailUrl: Option[String] = None
 )
 
 object ImageInfo {
-  implicit val imageInfoEncoder: Encoder[ImageInfo] = deriveConfiguredEncoder
-  implicit val imageInfoDecoder: Decoder[ImageInfo] = deriveConfiguredDecoder
+  implicit val imageinfoDecodetest: JsonDecoder[ImageInfo] = DeriveJsonDecoder.gen[ImageInfo]
+  implicit val imageinfoencodetest: JsonEncoder[ImageInfo] = DeriveJsonEncoder.gen[ImageInfo]
 }

--- a/core/src/com/bot4s/zmatrix/models/InviteEvent.scala
+++ b/core/src/com/bot4s/zmatrix/models/InviteEvent.scala
@@ -1,7 +1,7 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
-import io.circe.{ Decoder, HCursor, Json }
+import zio.json._
+import zio.json.ast._
 
 /**
  * Matrix Event class for events in invited rooms
@@ -17,8 +17,8 @@ object InviteEvent {
   // This corresponds to an m.room.member event
   final case class InviteMemberEvent(
     sender: String,
-    stateKey: String,
-    eventId: Option[String],
+    @jsonField("state_key") stateKey: String,
+    @jsonField("event_id") eventId: Option[String],
     content: InviteMemberEventContent
   ) extends InviteEvent
 
@@ -32,14 +32,14 @@ object InviteEvent {
     content: Json
   ) extends InviteEvent
 
-  implicit val inviteMemberEventDecoder: Decoder[InviteMemberEvent]               = deriveConfiguredDecoder
-  implicit val inviteMemberEventContentDecoder: Decoder[InviteMemberEventContent] = deriveConfiguredDecoder
+  implicit val inviteMemberEventContentDecoder: JsonDecoder[InviteMemberEventContent] = DeriveJsonDecoder.gen
+  implicit val inviteMemberEventDecoder: JsonDecoder[InviteMemberEvent]               = DeriveJsonDecoder.gen
 
-  implicit val inviteEventDecoder: Decoder[InviteEvent] = new Decoder[InviteEvent] {
-    def apply(c: HCursor): Decoder.Result[InviteEvent] =
-      c.downField("type").as[String].flatMap {
-        case "m.room.member" => c.as[InviteMemberEvent]
-        case label           => Right(GenericMemberEventContent(label, c.value))
-      }
+  implicit val inviteEventDecoder: JsonDecoder[InviteEvent] = JsonDecoder[Json].mapOrFail { json =>
+    json.get(JsonCursor.field("type")).flatMap(_.as[String]).flatMap {
+      case "m.room.member" => json.as[InviteMemberEvent]
+      case label           => Right(GenericMemberEventContent(label, json))
+
+    }
   }
 }

--- a/core/src/com/bot4s/zmatrix/models/MxcUri.scala
+++ b/core/src/com/bot4s/zmatrix/models/MxcUri.scala
@@ -1,9 +1,8 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import zio.json._
 
-final case class MxcUri(contentUri: String) {
+final case class MxcUri(@jsonField("content_uri") contentUri: String) {
   val (serverName, mediaId) = {
     val parts = contentUri.replace("mxc://", "").split("/").toList
     parts match {
@@ -14,5 +13,5 @@ final case class MxcUri(contentUri: String) {
 }
 
 object MxcUri {
-  implicit val mxcuriDecoder: Decoder[MxcUri] = deriveConfiguredDecoder
+  implicit val mxcuriDecoder: JsonDecoder[MxcUri] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/RoomCreation.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomCreation.scala
@@ -1,15 +1,14 @@
 package com.bot4s.zmatrix.models
-import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.{ deriveConfiguredDecoder, deriveConfiguredEncoder }
-import io.circe.{ Decoder, Encoder }
+
+import zio.json._
 
 object Visibility extends Enumeration {
   type Visibility = Value
   val publicRoom  = Value("public")
   val privateRoom = Value("private")
 
-  implicit val visibilityDecoder: Decoder[Visibility.Value] = Decoder.decodeEnumeration(Visibility)
-  implicit val visibilityEncoder: Encoder[Visibility.Value] = Encoder.encodeEnumeration(Visibility)
+  implicit val encoder: JsonEncoder[Visibility.Value] = JsonEncoder[String].contramap(_.toString)
+  implicit val decoder: JsonDecoder[Visibility.Value] = JsonDecoder[String].map(Visibility.withName)
 }
 
 object Preset extends Enumeration {
@@ -18,8 +17,8 @@ object Preset extends Enumeration {
   val publicChat         = Value("public_chat")
   val trustedPrivateChat = Value("trusted_private_chat")
 
-  implicit val presetDecoder: Decoder[Preset.Value] = Decoder.decodeEnumeration(Preset)
-  implicit val presetEncoder: Encoder[Preset.Value] = Encoder.encodeEnumeration(Preset)
+  implicit val encoder: JsonEncoder[Preset.Value] = JsonEncoder[String].contramap(_.toString)
+  implicit val decoder: JsonDecoder[Preset.Value] = JsonDecoder[String].map(Preset.withName)
 }
 
 /**
@@ -27,18 +26,17 @@ object Preset extends Enumeration {
  */
 final case class RoomCreationData(
   visibility: Option[Visibility.Visibility] = None,
-  roomAliasName: Option[String] = None,
+  @jsonField("room_alias_name") roomAliasName: Option[String] = None,
   name: Option[String] = None,
   topic: Option[String] = None,
   invite: Option[List[String]] = None,
-  roomVersion: Option[String] = None,
+  @jsonField("room_version") roomVersion: Option[String] = None,
   preset: Option[Preset.Preset] = None,
-  isDirect: Option[Boolean] = None
+  @jsonField("is_direct") isDirect: Option[Boolean] = None
 )
 
 object RoomCreationData {
-  implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
 
-  implicit val roomCreationDataEncoder: Encoder[RoomCreationData] = deriveConfiguredEncoder
-  implicit val roomCreationDataDecoder: Decoder[RoomCreationData] = deriveConfiguredDecoder
+  implicit val roomCreationDataEncoder: JsonEncoder[RoomCreationData] = DeriveJsonEncoder.gen[RoomCreationData]
+  implicit val roomCreationDataDecoder: JsonDecoder[RoomCreationData] = DeriveJsonDecoder.gen[RoomCreationData]
 }

--- a/core/src/com/bot4s/zmatrix/models/RoomId.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomId.scala
@@ -1,19 +1,21 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.generic.extras.semiauto._
-import io.circe.{ Decoder, Encoder, KeyDecoder }
+import zio.json._
 
 final case class RoomId(id: String) extends AnyVal
 
 object RoomId {
 
-  implicit val roomIdDecoder: Decoder[RoomId] =
-    deriveConfiguredDecoder[RoomId] or Decoder[String].map(x => RoomId(x))
+  implicit val roomIdDecoder: JsonDecoder[RoomId] =
+    DeriveJsonDecoder.gen[RoomId] orElse JsonDecoder[String].map(RoomId.apply)
 
-  implicit val roomIdEncoder: Encoder[RoomId] =
-    deriveConfiguredEncoder[RoomId]
+  implicit val roomIdEncoder: JsonEncoder[RoomId] =
+    DeriveJsonEncoder.gen[RoomId]
 
-  implicit val roomIdKeyDecoder: KeyDecoder[RoomId] =
-    key => Some(RoomId(key))
+  implicit val roomIdKeyEncoder: JsonFieldEncoder[RoomId] =
+    JsonFieldEncoder.string.contramap[RoomId](_.id)
+
+  implicit val roomIdKeyDecoder: JsonFieldDecoder[RoomId] =
+    JsonFieldDecoder.string.map(RoomId.apply)
 
 }

--- a/core/src/com/bot4s/zmatrix/models/Rooms.scala
+++ b/core/src/com/bot4s/zmatrix/models/Rooms.scala
@@ -1,7 +1,6 @@
 package com.bot4s.zmatrix.models
 
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto._
+import zio.json._
 
 final case class Rooms(
   invite: Option[Map[RoomId, InvitedRoom]],
@@ -16,10 +15,11 @@ final case class InvitedRoom(inviteState: InviteState)
 final case class InviteState(events: List[InviteEvent])
 
 object Rooms {
-  implicit val roomsDecoder: Decoder[Rooms] = deriveConfiguredDecoder
 
-  implicit val joinedRoomDecoder: Decoder[JoinedRoom]             = deriveConfiguredDecoder
-  implicit val joinedRoomEventDecoder: Decoder[RoomEventTimeline] = deriveConfiguredDecoder
-  implicit val invitedRoomDecoder: Decoder[InvitedRoom]           = deriveConfiguredDecoder
-  implicit val invitedRoomStateDecoder: Decoder[InviteState]      = deriveConfiguredDecoder
+  implicit lazy val joinedRoomEventDecoder: JsonDecoder[RoomEventTimeline] = DeriveJsonDecoder.gen
+  implicit lazy val joinedRoomDecoder: JsonDecoder[JoinedRoom]             = DeriveJsonDecoder.gen
+  implicit lazy val invitedRoomStateDecoder: JsonDecoder[InviteState]      = DeriveJsonDecoder.gen
+  implicit lazy val invitedRoomDecoder: JsonDecoder[InvitedRoom]           = DeriveJsonDecoder.gen
+
+  implicit lazy val roomsDecoder: JsonDecoder[Rooms] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/package.scala
+++ b/core/src/com/bot4s/zmatrix/models/package.scala
@@ -1,7 +1,0 @@
-package com.bot4s.zmatrix
-
-import io.circe.generic.extras.Configuration
-
-package object models {
-  implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
-}

--- a/core/src/com/bot4s/zmatrix/models/responses/EventResponse.scala
+++ b/core/src/com/bot4s/zmatrix/models/responses/EventResponse.scala
@@ -1,11 +1,9 @@
 package com.bot4s.zmatrix.models.responses
 
-import com.bot4s.zmatrix.models._
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import zio.json._
 
-final case class EventResponse(eventId: String)
+final case class EventResponse(@jsonField("event_id") eventId: String)
 
 object EventResponse {
-  implicit val decoder: Decoder[EventResponse] = deriveConfiguredDecoder
+  implicit val decoder: JsonDecoder[EventResponse] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/responses/JoinResponse.scala
+++ b/core/src/com/bot4s/zmatrix/models/responses/JoinResponse.scala
@@ -1,13 +1,13 @@
 package com.bot4s.zmatrix.models.responses
 
+import zio.json._
+
 import com.bot4s.zmatrix.models._
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 final case class JoinResponse(
-  roomId: RoomId
+  @jsonField("room_id") roomId: RoomId
 )
 
 object JoinResponse {
-  implicit val decoder: Decoder[JoinResponse] = deriveConfiguredDecoder
+  implicit val decoder: JsonDecoder[JoinResponse] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/responses/LoginResponse.scala
+++ b/core/src/com/bot4s/zmatrix/models/responses/LoginResponse.scala
@@ -1,16 +1,16 @@
 package com.bot4s.zmatrix.models.responses
 
+import zio.json._
+
 import com.bot4s.zmatrix.models._
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 final case class LoginResponse(
-  userId: String,
-  accessToken: AccessToken,
-  homeServer: String,
-  deviceId: String
+  @jsonField("user_id") userId: String,
+  @jsonField("access_token") accessToken: AccessToken,
+  @jsonField("home_server") homeServer: String,
+  @jsonField("device_id") deviceId: String
 )
 
 object LoginResponse {
-  implicit val decoder: Decoder[LoginResponse] = deriveConfiguredDecoder
+  implicit val decoder: JsonDecoder[LoginResponse] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/responses/SyncState.scala
+++ b/core/src/com/bot4s/zmatrix/models/responses/SyncState.scala
@@ -1,16 +1,16 @@
 package com.bot4s.zmatrix.models.responses
 
+import zio.json._
+
 import com.bot4s.zmatrix.models._
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
 /*
   Model the response from the sync endpoint as documented in
   https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3sync
  */
 final case class SyncState(
-  accountData: Option[AccountData],
-  nextBatch: String,
+  @jsonField("account_data") accountData: Option[AccountData],
+  @jsonField("next_batch") nextBatch: String,
   rooms: Option[Rooms]
 )
 
@@ -18,8 +18,8 @@ final case class AccountData(events: List[Event])
 final case class Event(`type`: String)
 
 object SyncState {
-  implicit val eventDecoder: Decoder[Event]             = deriveConfiguredDecoder
-  implicit val accountDataDecoder: Decoder[AccountData] = deriveConfiguredDecoder
+  implicit val eventDecoder: JsonDecoder[Event]             = DeriveJsonDecoder.gen
+  implicit val accountDataDecoder: JsonDecoder[AccountData] = DeriveJsonDecoder.gen
 
-  implicit val syncStateDecoder: Decoder[SyncState] = deriveConfiguredDecoder
+  implicit val syncStateDecoder: JsonDecoder[SyncState] = DeriveJsonDecoder.gen
 }

--- a/core/src/com/bot4s/zmatrix/models/responses/UserResponse.scala
+++ b/core/src/com/bot4s/zmatrix/models/responses/UserResponse.scala
@@ -1,11 +1,9 @@
 package com.bot4s.zmatrix.models.responses
 
-import com.bot4s.zmatrix.models._
-import io.circe.Decoder
-import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import zio.json._
 
-final case class UserResponse(userId: String)
+final case class UserResponse(@jsonField("user_id") userId: String)
 
 object UserResponse {
-  implicit val decoder: Decoder[UserResponse] = deriveConfiguredDecoder
+  implicit val decoder: JsonDecoder[UserResponse] = DeriveJsonDecoder.gen
 }

--- a/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
+++ b/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
@@ -1,14 +1,14 @@
 package com.bot4s.zmatrix
 
+import zio.json._
+import zio.json.ast._
 import zio.test.Assertion._
 import zio.test._
 
 import com.bot4s.zmatrix.models.RoomEvent._
 import com.bot4s.zmatrix.models.RoomMessageType._
-import com.bot4s.zmatrix.models.{ MessageEvent, Preset, RoomCreationData, RoomEvent, RoomMessageType }
-import io.circe.Json
-import io.circe.parser.decode
-import io.circe.syntax._
+import com.bot4s.zmatrix.models._
+import com.bot4s.zmatrix.models.responses.SyncState
 
 object SerializationSpec extends ZIOSpecDefault {
 
@@ -20,37 +20,39 @@ object SerializationSpec extends ZIOSpecDefault {
           roomAliasName = Some("testroomalias"),
           name = Some("testroom"),
           topic = Some("Custom topic")
-        ).asJson.dropNullValues
+        ).toJsonAST
 
         assert(json)(
-          equalTo(
-            Json.obj(
-              "preset"          -> Json.fromString("public_chat"),
-              "room_alias_name" -> Json.fromString("testroomalias"),
-              "name"            -> Json.fromString("testroom"),
-              "topic"           -> Json.fromString("Custom topic")
+          isRight(
+            equalTo(
+              Json.Obj(
+                "preset"          -> Json.Str("public_chat"),
+                "room_alias_name" -> Json.Str("testroomalias"),
+                "name"            -> Json.Str("testroom"),
+                "topic"           -> Json.Str("Custom topic")
+              )
             )
           )
         )
       },
       test("RoomMessageTextContent as RoomMessageType") {
-        val obj = (RoomMessageTextContent("test"): RoomMessageType).asJson.deepDropNullValues
-        assert(obj.deepDropNullValues)(
-          equalTo(Json.obj("body" -> Json.fromString("test"), "msgtype" -> Json.fromString("m.text")))
+        val obj = (RoomMessageTextContent("test"): RoomMessageType).toJsonAST
+        assert(obj)(
+          isRight(equalTo(Json.Obj("body" -> Json.Str("test"), "msgtype" -> Json.Str("m.text"))))
         )
       },
       test("RoomMessageTextContent") {
-        val obj = RoomMessageTextContent("test").asJson.deepDropNullValues
-        assert(obj)(equalTo(Json.obj("body" -> Json.fromString("test"), "msgtype" -> Json.fromString("m.text"))))
+        val obj = RoomMessageTextContent("test").toJsonAST
+        assert(obj)(isRight(equalTo(Json.Obj("body" -> Json.Str("test"), "msgtype" -> Json.Str("m.text")))))
       },
       test("RoomEmptyMessage") {
-        val obj = RoomMessageEmpty.asJson
-        assert(obj)(equalTo(Json.obj()))
+        val obj = RoomMessageEmpty.toJsonAST
+        assert(obj)(isRight(equalTo(Json.Obj())))
       }
     ),
     suite("decoders")(
       test("RoomMessageType decoder") {
-        val res = decode[RoomMessageType]("""{ "body": "test", "msgtype": "m.text" }""")
+        val res = """{ "body": "test", "msgtype": "m.text" }""".fromJson[RoomMessageType]
         assert(res)(isRight(equalTo(RoomMessageTextContent("test"))))
       },
       test("m.room.message") {
@@ -70,7 +72,7 @@ object SerializationSpec extends ZIOSpecDefault {
   "room_id": "!my_roomt:matrix.org"
 }
       """
-        val res    = decode[RoomEvent](source)
+        val res    = source.fromJson[RoomEvent]
         assert(res)(
           isRight(
             equalTo(
@@ -108,7 +110,7 @@ object SerializationSpec extends ZIOSpecDefault {
   "event_id": "$gqlw0nXSUGTqfgsFMvdHJagjPkcuUy7cTG79sjGcVqc"
 }
       """
-        val res    = decode[RoomEvent](source)
+        val res    = source.fromJson[RoomEvent]
         assert(res)(
           isRight(
             equalTo(
@@ -120,6 +122,201 @@ object SerializationSpec extends ZIOSpecDefault {
             )
           )
         )
+      },
+      test("RoomId") {
+        assert(""""test"""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
+        assert("""{"id": "test"}""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
+      },
+      test("RoomMessageTextContent") {
+        val content = """
+        {
+            "msgtype": "m.text",
+            "body": "success"
+        }
+        """
+
+        assert(content.fromJson[RoomMessageType])(isRight(equalTo(RoomMessageTextContent("success"))))
+        assert(content.fromJson[RoomMessageTextContent])(isRight(equalTo(RoomMessageTextContent("success"))))
+      },
+      test("RoomMessageTextContent - formatted body") {
+        val content = """
+        {
+            "msgtype": "m.text",
+            "body": "success",
+            "formatted_body":"success - formatted"
+        }
+        """
+
+        assert(content.fromJson[RoomMessageType])(
+          isRight(equalTo(RoomMessageTextContent("success", formattedBody = Some("success - formatted"))))
+        )
+        assert(content.fromJson[RoomMessageTextContent])(
+          isRight(equalTo(RoomMessageTextContent("success", formattedBody = Some("success - formatted"))))
+        )
+      },
+      test("RoomMessageImageContent") {
+        val content = """
+        {
+            "msgtype": "m.image",
+            "body": "success",
+            "url": "http://fake.matrixbot/bot.jpg"
+        }
+        """
+
+        assert(content.fromJson[RoomMessageType])(
+          isRight(equalTo(RoomMessageImageContent("success", Some("http://fake.matrixbot/bot.jpg"))))
+        )
+        assert(content.fromJson[RoomMessageImageContent])(
+          isRight(equalTo(RoomMessageImageContent("success", Some("http://fake.matrixbot/bot.jpg"))))
+        )
+      },
+      test("RoomMessageTextContent encode") {
+        val result = """
+        {
+            "body": "success",
+            "msgtype": "m.text"
+        }
+        """.replaceAll("\\s", "")
+        assert(RoomMessageTextContent("success").toJson)(equalTo(result))
+      },
+      test("decode") {
+        val content = """
+        {
+            "next_batch": "s735798_20141841_27974_715432_326180_115_59046_739295_0",
+            "presence": {
+                "events": [
+                    {
+                        "type": "m.presence",
+                        "sender": "@ex0ns:matrix.org",
+                        "content": {
+                            "presence": "online",
+                            "last_active_ago": 215,
+                            "currently_active": true
+                        }
+                    },
+                    {
+                        "type": "m.presence",
+                        "sender": "@ziobot:matrix.org",
+                        "content": {
+                            "presence": "online",
+                            "last_active_ago": 28,
+                            "currently_active": true
+                        }
+                    }
+                ]
+            },
+            "device_lists": {
+                "changed": [
+                    "@ziobot:matrix.org"
+                ]
+            },
+            "device_one_time_keys_count": {
+                "signed_curve25519": 0
+            },
+            "org.matrix.msc2732.device_unused_fallback_key_types": [],
+            "device_unused_fallback_key_types": [],
+            "rooms": {
+                "join": {
+                    "!sdUfnyuUPYtPGbcZhj:matrix.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@ziobot:matrix.org",
+                                    "content": {
+                                        "body": "CC Logo",
+                                        "url": "mxc://matrix.org/IkaslHFPELmKVhXDDGMCKUWt",
+                                        "info": {
+                                            "h": 100,
+                                            "w": 100
+                                        },
+                                        "msgtype": "m.image"
+                                    },
+                                    "origin_server_ts": 1667982642143,
+                                    "unsigned": {
+                                        "age": 390843
+                                    },
+                                    "event_id": "$sgL3nknhUljN5T7bqCYS5FC8pYK3GBe_o7JXC94NDfI"
+                                }
+                            ],
+                            "prev_batch": "s735790_20141841_27974_715432_326180_115_59046_739295_0",
+                            "limited": false
+                        },
+                        "state": {
+                            "events": []
+                        },
+                        "account_data": {
+                            "events": []
+                        },
+                        "ephemeral": {
+                            "events": [
+                                {
+                                    "type": "m.receipt",
+                                    "content": {
+                                        "$sgL3nknhUljN5T7bqCYS5FC8pYK3GBe_o7JXC94NDfI": {
+                                            "m.read": {
+                                                "@ex0ns:matrix.org": {
+                                                    "ts": 1667982687776
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "unread_notifications": {
+                            "notification_count": 29,
+                            "highlight_count": 0
+                        },
+                        "summary": {}
+                    }
+                }
+            }
+        }
+      
+      """
+
+        assert(content.fromJson[SyncState])(
+          isRight(
+            equalTo(
+              SyncState(
+                None,
+                "s735798_20141841_27974_715432_326180_115_59046_739295_0",
+                Some(
+                  Rooms(
+                    None,
+                    Some(
+                      Map(
+                        RoomId("!sdUfnyuUPYtPGbcZhj:matrix.org") -> JoinedRoom(
+                          RoomEventTimeline(
+                            List(
+                              MessageEvent(
+                                "@ziobot:matrix.org",
+                                "$sgL3nknhUljN5T7bqCYS5FC8pYK3GBe_o7JXC94NDfI",
+                                RoomMessageImageContent(
+                                  "CC Logo",
+                                  Some("mxc://matrix.org/IkaslHFPELmKVhXDDGMCKUWt"),
+                                  Some(
+                                    ImageInfo(
+                                      w = Some(100),
+                                      h = Some(100)
+                                    )
+                                  )
+                                )
+                              )
+                            ),
+                            false
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+
       }
     )
   )


### PR DESCRIPTION
This is a first step toward the migration to Scala 3. We could have simply remove the `circe-generic` and `circe-generic-extras` dependencies and write the encoder/decoder manually but zio-json does it pretty well by default and might be a better bet for the future (that remains to be seen, but only time will tell).

The transition was not flawless, mainly:

- The conversion to snake case must now be done using annotations
- JsonEncoder and their contramap method require to deal with error that I don't know anything about
- Discriminating the trait based on the value of a field was not straightforward and require to use the `zio.json.ast` package
- There is no `JsonDecoder` instance for `Unit` so it use a combination of `Json` and `.as(())` to map that to `Unit` (maybe we should not return `Unit` in the first place, but that is another question).