### PR TITLE
chore(desps): remove autoderivation from pureconfig

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -50,9 +50,7 @@ class CoreModule(val crossScalaVersion: String) extends ExtendedCrossScalaModule
     ivy"com.softwaremill.sttp.client3::core:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio-json:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}",
-    ivy"com.github.pureconfig::pureconfig:${pureConfigVersion}",
-    // https://github.com/com-lihaoyi/mill/issues/1797
-    ivy"org.scala-lang:scala-reflect:${crossScalaVersion}"
+    ivy"com.github.pureconfig::pureconfig-core:${pureConfigVersion}"
   )
 
   override def scalacOptions = Seq(

--- a/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
+++ b/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
@@ -2,9 +2,8 @@ package com.bot4s.zmatrix
 
 import zio._
 
-import pureconfig.ConfigSource
+import pureconfig._
 import pureconfig.error.ConfigReaderFailures
-import pureconfig.generic.auto._
 
 final case class Config(
   matrix: MatrixConfigurationContent
@@ -32,6 +31,12 @@ object MatrixConfiguration {
   val DEFAULT_API_PREFIX  = "/_matrix"
   val DEFAULT_API_VERSION = "v3"
   val DEFAULT_CONFIG_FILE = "bot.conf"
+
+  private implicit val matrixContentConfigReader: ConfigReader[MatrixConfigurationContent] =
+    ConfigReader.forProduct6("home-server", "api-prefix", "api-version", "user-id", "device-name", "device-id")(
+      MatrixConfigurationContent(_, _, _, _, _, _)
+    )
+  private implicit val configReader: ConfigReader[Config] = ConfigReader.forProduct1("matrix")(Config(_))
 
   def get: URIO[MatrixConfiguration, Config] = ZIO.serviceWithZIO(_.get)
 

--- a/core/src/com/bot4s/zmatrix/models/AccessToken.scala
+++ b/core/src/com/bot4s/zmatrix/models/AccessToken.scala
@@ -5,7 +5,5 @@ import zio.json._
 final case class AccessToken(token: String) extends AnyVal
 
 object AccessToken {
-  // We want to support both the derivation with the token field and also a flattened "anyval" decoding
-  implicit val roomIdDecoder: JsonDecoder[AccessToken] =
-    DeriveJsonDecoder.gen[AccessToken] orElse JsonDecoder[String].map(AccessToken.apply)
+  implicit val roomIdDecoder: JsonDecoder[AccessToken] = JsonDecoder[String].map(AccessToken.apply)
 }

--- a/core/src/com/bot4s/zmatrix/models/RoomEvent.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomEvent.scala
@@ -35,11 +35,11 @@ object RoomEvent {
     content: Json
   ) extends RoomEvent
 
-  implicit val roomMessageDecoder: JsonDecoder[MessageEvent]                = DeriveJsonDecoder.gen[MessageEvent]
-  implicit val topicMessageContentDecoder: JsonDecoder[TopicMessageContent] = DeriveJsonDecoder.gen[TopicMessageContent]
-  implicit val topicMessageDecoder: JsonDecoder[TopicEvent]                 = DeriveJsonDecoder.gen[TopicEvent]
+  implicit val roomMessageDecoder: JsonDecoder[MessageEvent]                = DeriveJsonDecoder.gen
+  implicit val topicMessageContentDecoder: JsonDecoder[TopicMessageContent] = DeriveJsonDecoder.gen
+  implicit val topicMessageDecoder: JsonDecoder[TopicEvent]                 = DeriveJsonDecoder.gen
 
-  implicit val roomEventDecoder = JsonDecoder[Json].mapOrFail { json =>
+  implicit val roomEventDecoder: JsonDecoder[RoomEvent] = JsonDecoder[Json].mapOrFail { json =>
     json.get(JsonCursor.field("type")).flatMap(_.as[String]).flatMap {
       case "m.room.message" => json.as[MessageEvent]
       case "m.room.topic"   => json.as[TopicEvent]

--- a/core/src/com/bot4s/zmatrix/models/RoomId.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomId.scala
@@ -7,10 +7,10 @@ final case class RoomId(id: String) extends AnyVal
 object RoomId {
 
   implicit val roomIdDecoder: JsonDecoder[RoomId] =
-    DeriveJsonDecoder.gen[RoomId] orElse JsonDecoder[String].map(RoomId.apply)
+    JsonDecoder[String].map(RoomId.apply)
 
   implicit val roomIdEncoder: JsonEncoder[RoomId] =
-    DeriveJsonEncoder.gen[RoomId]
+    JsonEncoder.string.contramap[RoomId](_.id)
 
   implicit val roomIdKeyEncoder: JsonFieldEncoder[RoomId] =
     JsonFieldEncoder.string.contramap[RoomId](_.id)

--- a/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
+++ b/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
@@ -125,7 +125,6 @@ object SerializationSpec extends ZIOSpecDefault {
       },
       test("RoomId") {
         assert(""""test"""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
-        assert("""{"id": "test"}""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
       },
       test("RoomMessageTextContent") {
         val content = """


### PR DESCRIPTION
This is the last dependency preventing us from being compatible with Scala 3.
The auto-derivation was not that important here and writing those helper class is far from perfect but the configuration in this case is pretty static and will probably not change a lot in the future.

Types annotations were also added on implicits because this will be mandatory to cross-compile with scala 3.