### PR TITLE
chore: release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Add the following dependency to your project's build file
 
 ```scala
 // sbt
-"com.bot4s" %% "zmatrix" % "0.3.4"
+"com.bot4s" %% "zmatrix" % "0.4.0"
 // mill
-ivy"com.bot4s::zmatrix:0.3.4"
+ivy"com.bot4s::zmatrix:0.4.0"
 ```
 
 It is also possible to get the latest snapshot from [Snapshot Artifacts][link-sonatypesnapshots] by adding the following

--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,7 @@ val scalaVersions = List("2.12.19", "2.13.13", "3.3.3")
 
 trait Publishable extends PublishModule {
   override def artifactName   = "zmatrix"
-  override def publishVersion = "0.3.4"
+  override def publishVersion = "0.4.0"
 
   override def pomSettings = PomSettings(
     description = "Matrix.org API client written using ZIO",


### PR DESCRIPTION
releasing a minor because of the changes to the underlying ZIO library (in particular zio-config) even though there were no changes in the external API